### PR TITLE
feat: Add use-constant for initialState and getReducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
   },
   "size-limit": [
     {
-      "path": "dist/usemachine.cjs.production.min.js",
+      "path": "dist/usestatemachine.cjs.production.min.js",
       "limit": "512 B"
     },
     {
-      "path": "dist/usemachine.esm.js",
+      "path": "dist/usestatemachine.esm.js",
       "limit": "512 B"
     }
   ]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, Dispatch } from 'react';
+import { useEffect, useReducer, Dispatch, useRef } from 'react';
 
 type Transition =
   | string
@@ -84,19 +84,28 @@ const getReducer = <
     };
   };
 
+const useConstant = <T,>(init: () => T) => {
+  const ref = useRef<T | null>(null);
+
+  if (ref.current === null) {
+    ref.current = init();
+  }
+  return ref.current;
+};
+
 export default function useStateMachine<Context extends Record<PropertyKey, any>>(context?: Context) {
   return function useStateMachineWithContext<Config extends MachineConfig<Context>>(config: Config) {
     type IndexableState = keyof typeof config.states;
     type State = keyof Config['states'];
     type Event = KeysOfTransition<TransitionEvent<Config['states']>>;
 
-    const initialState = {
+    const initialState = useConstant(() => ({
       value: config.initial as State,
       context: context ?? ({} as Context),
       nextEvents: Object.keys(config.states[config.initial].on ?? []) as Event[],
-    };
+    }));
 
-    const reducer = getReducer<Context, Config, State, Event>(config);
+    const reducer = useConstant(() => getReducer<Context, Config, State, Event>(config));
 
     const [machine, send] = useReducer(reducer, initialState);
 


### PR DESCRIPTION
Really interesting library. Just adding `useConstant` to ensure `getReducer` and `initialState` exist only once.

Also fixing the path names for `size-limit` 