### PR TITLE
Generic over states and transitions

### DIFF
--- a/test/useStateMachine.test.tsx
+++ b/test/useStateMachine.test.tsx
@@ -18,7 +18,7 @@ describe('useStateMachine', () => {
     );
 
     expect(result.current[0]).toStrictEqual({
-      context: {},
+      context: undefined,
       value: 'inactive',
       nextEvents: ['TOGGLE'],
     });
@@ -44,7 +44,7 @@ describe('useStateMachine', () => {
     });
 
     expect(result.current[0]).toStrictEqual({
-      context: {},
+      context: undefined,
       value: 'active',
       nextEvents: ['TOGGLE'],
     });
@@ -72,7 +72,7 @@ describe('useStateMachine', () => {
     });
 
     expect(result.current[0]).toStrictEqual({
-      context: {},
+      context: undefined,
       value: 'inactive',
       nextEvents: ['TOGGLE'],
     });
@@ -106,7 +106,7 @@ describe('useStateMachine', () => {
     });
 
     expect(result.current[0]).toStrictEqual({
-      context: {},
+      context: undefined,
       value: 'active',
       nextEvents: ['TOGGLE'],
     });
@@ -181,7 +181,7 @@ describe('useStateMachine', () => {
 
       expect(guard).toHaveBeenCalled();
       expect(result.current[0]).toStrictEqual({
-        context: {},
+        context: undefined,
         value: 'inactive',
         nextEvents: ['TOGGLE'],
       });
@@ -215,7 +215,7 @@ describe('useStateMachine', () => {
 
       expect(guard).toHaveBeenCalled();
       expect(result.current[0]).toStrictEqual({
-        context: {},
+        context: undefined,
         value: 'active',
         nextEvents: ['TOGGLE'],
       });


### PR DESCRIPTION
PR for my suggestion under your reddit post.

Type changes:

- Removed all `any` types and `as` casts (except for one). This means that everything is now verified by TS.
- Removed the `KeysOfTransition` helper type. TypeScript can infer all state and transition types, so this helper is no longer necessary.
- Removed `BaseStateConfig` and `BaseConfig`. These were purely internal types. I don't know why you added them in the first place. I just used `MachineStateConfig` and `MachineConfig` everywhere.
- The type parameter of `useStateMachine` is no longer constrained. From what I see, this only got in the way of TS inferring the type. I'll re-add it if it's important.
- `useStateMachineWithContext` is now generic over states and transitions and not over the config type. This allows TS to infer all states and transitions. However, this is a breaking change for TS users.

Behavioral changes:

- `reducer`: I changed the [`currentState?.on`](https://github.com/cassiozen/useStateMachine/blob/7feb5725a5bba5f016be403da82730abb04eff29/src/index.tsx#L61) to `currentState.on`. Since the state machine is now type-checked, users will get a compilation error if they try to transition into an undefined state. Therefore `currentState` must be non-nullable.
- Context will no longer [default to `{}`](https://github.com/cassiozen/useStateMachine/blob/7feb5725a5bba5f016be403da82730abb04eff29/src/index.tsx#L105). This was actually a bug of the old implementation. I fixed this bug here because TS would not compile (that's the advantage of not using `any` and `as` :) ). Example:
    ```ts
    const [state, send] = useStateMachine<{ foo: { bar: number } }>()({
        initial: 'inactive',
        states: {
            inactive: {
                on: { TOGGLE: 'active' },
            },
            active: {
                on: {
                    TOGGLE: {
                        target: 'inactive',
                        guard(context) {
                            // no type error but this will crash at runtime
                            return context.foo.bar > 4;
                        }
                    }
                },
            },
        },
    });

    console.log(state); // { value: 'inactive', nextEvents: ['TOGGLE'] }

    send('TOGGLE');

    console.log(state); // { value: 'active', nextEvents: ['TOGGLE'] }
    
    send('TOGGLE'); // crash
    ```


Feel free to request changes.

You can try out everything [here](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgVwM4FMCiAzb6DGMANChgEroAmy+6UJAIsKmAIYz4AWJa6F2cAL5xsUCCDgByKOlaFJAbgCwAKFUwAnmHRwAKlFYA7VMBjAIhgDwBhCzHQAPYnADKcR-cOVUcVDCjAhgDmAHxwALyqcNFwAD6uUTHxCIkxMTCsUEHoMABcrsoqaWlByJmUAPz5ABT4dh75tob2TgCUEWEARhAQADayhoVpgoXqWjpNLTAAqmCU7Og29U5h4XC1y3lwkx7t4WE7TqMqgfZQ2HI6ALJynIHoLhn2TdjAQUvNHiRuHuhePn4AsESLp3E4-t5fP5AqFEKk4BYqnCisVogBtADW6A0cECegAukj9EYTGYLB8pt8QkMYiN4ehcAQYEjqvC0hgvPkmCx2FxLLoQkQ2TFWKgTEFDFzmGwOJwKR5ZvN7PKViF4XswgA3CDAShxdbVDmUKU82X8wVwUXiyVwbkyvmHGZzBYqmAhEIauDa3WtQqCVSqU50C60OA3Lj3F5vV3fMGeSGAmEguMQgHQ4JhFIo6KBUzAVi9fIuGnRPwLVD5LOo9FYnF4lz4-Lhu6GB5PdBR96O74g6nwukqf1qE6fc6XVztmOuFP-KFAoLJ36zxMZ5FpTUF5DoIsluB1T5ORqbXetpyYTV-GAVvRo-F+gMjs4hnSKhbny+uzPwzTafKSV-2Io8LIM6Zw1PuUxHgeMCeo696PsG47EsYeYWO+zT8jOCbprCVbpOMf7IaS5iGEB2ZwKeWy6PBP46OhMBTqCS7YfOqxwABWAXhhjphPERGoYY9Hmsc2DIIYhAkXA2QwI8LrdtOzFpvOi7gsuOEhBs0FQZSe4WK8QRNrckZ6dG8kuL2JAbr0W5Fq0RaTmZvZrjE+5+AihgRLphj6QAdGW9ioGiVlbviPkWMcaQyDAyBQB5eGosF6BCuRaQQV8wrRJR9HXhYcAVHAADynQAFZMj5taoNUFjtKKN74nA+S3slwzwaooniWSHnSRQ1C0FAljwt28I-KpLFJvCTGjUpMKqBp+76YZEatp2U7mXoHrOdEUUxR57USblMi9XQrIpTE-nbhOcmbD263NdW6BcVsQnyQK6r2Vd0E3QKm3FMAAjVA9l4+bREThGsABEHHg+08XVtEAD08NwAAkqOhgFpa+0eTAEAoKBOhpU4GXFNtsU-XD66bhd50+Yld0U8UhNbIDzQ+SBSrHTTTOtPTDMxFlj3XjTAuXqgvNwwOEvuL0GDk9WrnwPgMUyM0sn2J581vH57aBTTiV3sTqUWG5lFqxd-GdatvEoF4DL3HqaxK1AKsye2YWGBUPloizMA+ZRBvDnzcCIyjAgwJwdA6MwFG45QdutnqlFQgsJCkx5shQL0GiGzEf3rAAhKb7btGnyf2BFfP9PAGRZDkO45zm-20RAAhFwsoNrJIK5BJIMMN8UNfSZ5bfl-3wjoDLOiw0HIfI2HEcyJai+lOUYu4oY2pYnA4foBIRh6qXGdZ7i886P4JICbiPhx4YwBUP3aR59UI-oD5K9QHqABkn9wIXHhm2-MoH9DRu25n3U6Qcto5B2mXdAu4g5DgfukTIQ81gv2BignI8DqyIIgSTaBZNpJmxAQsHyTMSCawXNvTBMFsHRCHC1VQuC9qdVIB2Y2GQMICmqLmLY1RPS6DsnoH6Cs4AyAEGsXg-BMLxEMMgXovQNJyIUb6B8j9-riLIcrS8HcKLyN6OAuGminYu08rw-hu4GExFLsY7RzRWoqBBtMDAZtmz3AAOqmE4I6T8nlLAjXjNNYEwjFJzhhHNEyBkwxGWWpE1avZPRonOu9ZUjlbq+AhCae0coBQBxYZJXgriYnoGRuAXon5NKQW2JsIRzi2wLDca2Tx4cfE8R+qXfJuVCntkaegZp3jNj+KwkEqhk1AlhIzJpBa0SlrsO8qZa6rgEmNTNvE9JdpeQ5JCPVLMxNRG8PzL0M2nleBNDLBhVZaSBQaX4R0KSORiHkK8vpChkSfIHILK0VRgd5YcLEVQGgdATkYDOZwmA1Rbn7HuTAHqgL+pXIifMoIXyK6olEWiEAxSSBGnqpI8gAK+rVEOnCkgHyjnFzocHJGugI54w5lAEQYksYZNnEYdeZx0a9HcI9beuMd7-KOgynG28AhBGyEK2lchooY3ZgsPZfyjQcSgFkzZroOKfjYtUWVZxPRGmqEgWi+RIb43BjwfGDLBDfLhiHGlOgwDIE6L0YA+A6ULAZZ09ODhIAYD1MK-lvAoDyuMPAI0AA5BotppSqu+msZ+uw7l6oNQROA4MLYkVNRRDwQhvnE14DgPAhAIWemnr84NYJTAazeedQKmLZm0ypoSHyDIC3Mh8oaCE4anDYohEqq1fNS7NwEI4CtYNO4eskHldYnph3grDV8FllBe0NRtnHV4CdKWCBIBi4p9brLoHxDmvBpdt2zO7V4TtMAA6MMHA+RwkBYBwFXaweR8APVsKKbM-h+Q6kfpbH0rxPixKrvtn2FQd7oDwCfS+xlHUCkuJ6cUipTNtK7G-fBhpxT+mtM2KB8DD6oO9FfUy1h3SMOzKQ5sJEjpanofsL0rDgzHT6iA-HKguGvUQcfQyZ9hGYPMtI3RxDPFKkeCozUtD9TBOzIY9BV0zHbZrrY+0ghHkBPoF6aUsAvQRNtAcbDdF50z2UFxe+hDn7Wj6uJmSv8gQpXAAvJIcWZ0daVn7rZiSF5XN4LhhYSsegCoAHEAsABlMB-jsw5kgmBQ0AEEABCoXwsefQBOzdY8nOogixdEtDNfOIH80FxLUh3NmEi7aZGLh4tFckCV+zKWhAZYps2pktycuQNcn0V+vQIBBGqJIAAUmgeAl5I6+tpTF5LsDe6UpnkjFwrAQAE36EYECcAZQcstD4AABnmxkhAtu5CQaiWeAgNAQGQP86KZNWB8c6qS+AAB3YACixFiTgA9iOnq8zBG3rSmmR38FXY8pCsIHX+g+W671gbQ24DBYZNXcbk3zrTYB2l7ztJGto+GIeo2xhOsQ56yQ+wvoqX5cSjZ9GyXHOZrPILRqkhdCBZC5gSQ9VcHsghH1xnhWWc45iCHYLPXryDbciNw6v2dATdKzoc6aiXLG3x5Don6ASchyQOTqQWXqci2aNeNEDOmehdZ0IJhQA).