### PR TITLE
Verbose Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ The `state` consists of three properties: `value`, `nextEvents` and `context`.
 The configuration object should contain:
 
 - initial: The initial state node this machine should be in
+- verbose(optional): If true, will log every context & state changes. Log messages will be stripped out in the production build.
 - states: Define each of the possible states:
 
 ```typescript
 const [state, send] = useStateMachine()({
   initial: 'inactive',
+  verbose: true,
   states: {
     inactive: {},
     active: {},

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,9 @@
+export default function log(message: string, ...optionalParams: any[]) {
+  if (process.env.NODE_ENV === 'development') {
+    const logArguments = ['%cuseStateMachine ' + `%c${message}`, 'color: #888;', 'color: default;', ...optionalParams];
+
+    // Console.log clearly accepts parameters other than string, but TypeScript is complaining, so...
+    // @ts-ignore
+    console.log.apply(null, logArguments);
+  }
+}


### PR DESCRIPTION
Useful for debugging. If you set `verbose: true` in the state machine configuration, it will `console.log` every time:

- A transition is successful (the state machine changed to a different state)
- A transition is unsuccessful (because it was guarded or the state didn't listen to the event that was sent)
- The context changed