### PR TITLE
fix: log invalid event provided as object

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "tslib": "^2.1.0",
     "typescript": "^3.9.4"
   },
+  "jest": {
+    "resetMocks": true
+  },
   "husky": {
     "hooks": {
       "pre-commit": "tsdx lint"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -119,7 +119,7 @@ function getReducer<Context, Events, State extends string, EventString extends s
 
       // If there is no defined next state, return early
       if (!nextState) {
-        if (config.verbose) log(`Current state %o doesn't listen to event "${eventObject.type}".`, state);
+        if (config.verbose) log(`Current state %o doesn't listen to event type "${eventObject.type}".`, state);
         return state;
       }
 
@@ -168,11 +168,12 @@ function useStateMachineImpl<Context, Events>(context: Context): UseStateMachine
     const [machine, dispatch] = useReducer(reducer, initialState);
 
     // The public dispatch/send function exposed to the user
-    const send: Dispatch<SendEvent<Events, EventString>> = useConstant(() => next =>
-      dispatch({
-        type: DispatchType.Transition,
-        next,
-      })
+    const send: Dispatch<SendEvent<Events, EventString>> = useConstant(
+      () => (next) =>
+        dispatch({
+          type: DispatchType.Transition,
+          next,
+        })
     );
 
     // The updater function sends an internal event to the reducer to trigger the actual update

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -119,7 +119,7 @@ function getReducer<Context, Events, State extends string, EventString extends s
 
       // If there is no defined next state, return early
       if (!nextState) {
-        if (config.verbose) log(`Current state %o doesn't listen to event "${event.next}".`, state);
+        if (config.verbose) log(`Current state %o doesn't listen to event "${eventObject.type}".`, state);
         return state;
       }
 

--- a/test/useStateMachine.test.tsx
+++ b/test/useStateMachine.test.tsx
@@ -245,40 +245,6 @@ describe('useStateMachine', () => {
       });
       expect(effect.mock.calls[0][2]).toStrictEqual({ type: 'ACTIVATE', number: 10 });
     });
-
-    it('should log when invalid event is provided as string', () => {
-      renderHook(() =>
-        useStateMachine()({
-          verbose: true,
-          initial: 'idle',
-          states: {
-            idle: {
-              effect: send => send('invalid'),
-            },
-          },
-        })
-      );
-
-      expect(loggerMock).toHaveBeenCalledTimes(1);
-      expect(loggerMock.mock.calls[0][0]).toMatch(/invalid/);
-    });
-
-    it('should log when invalid event is provided as object', () => {
-      renderHook(() =>
-        useStateMachine()({
-          verbose: true,
-          initial: 'idle',
-          states: {
-            idle: {
-              effect: send => send({ type: 'invalid' }),
-            },
-          },
-        })
-      );
-
-      expect(loggerMock).toHaveBeenCalledTimes(1);
-      expect(loggerMock.mock.calls[0][0]).toMatch(/invalid/);
-    });
   });
   describe('guarded transitions', () => {
     it('should block transitions with guard returning false', () => {
@@ -387,7 +353,7 @@ describe('useStateMachine', () => {
             active: {
               on: { TOGGLE: 'inactive' },
               effect(_, update) {
-                update(context => ({ toggleCount: context.toggleCount + 1 }));
+                update((context) => ({ toggleCount: context.toggleCount + 1 }));
               },
             },
           },
@@ -415,7 +381,7 @@ describe('useStateMachine', () => {
             inactive: {
               on: { TOGGLE: 'active' },
               effect(_, update) {
-                return () => update(context => ({ toggleCount: context.toggleCount + 1 }));
+                return () => update((context) => ({ toggleCount: context.toggleCount + 1 }));
               },
             },
             active: {
@@ -437,6 +403,41 @@ describe('useStateMachine', () => {
         },
         nextEvents: ['TOGGLE'],
       });
+    });
+  });
+  describe('Verbose Mode (Logger)', () => {
+    it('should log when invalid event is provided as string', () => {
+      renderHook(() =>
+        useStateMachine()({
+          verbose: true,
+          initial: 'idle',
+          states: {
+            idle: {
+              effect: (send) => send('invalid'),
+            },
+          },
+        })
+      );
+
+      expect(loggerMock).toHaveBeenCalledTimes(1);
+      expect(loggerMock.mock.calls[0][0]).toMatch(/invalid/);
+    });
+
+    it('should log when invalid event is provided as object', () => {
+      renderHook(() =>
+        useStateMachine()({
+          verbose: true,
+          initial: 'idle',
+          states: {
+            idle: {
+              effect: (send) => send({ type: 'invalid' }),
+            },
+          },
+        })
+      );
+
+      expect(loggerMock).toHaveBeenCalledTimes(1);
+      expect(loggerMock.mock.calls[0][0]).toMatch(/invalid/);
     });
   });
   describe('React performance', () => {


### PR DESCRIPTION
Currently, when doing `send({type: 'invalid'})`, we get `[object Object]` logged - [demo](https://codesandbox.io/s/kxetm?file=/src/App.js).

Question: Should we stringify the whole object instead of logging only the `type`?