### PR TITLE
New param signature for effects & guards

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -233,8 +233,15 @@ function useStateMachineImpl<Context, Events>(context: Context): UseStateMachine
     };
 
     useEffect(() => {
-      const exit = config.states[machine.value]?.effect?.({ send, setContext, event: machine.event, context });
-      return typeof exit === 'function' ? () => exit({ send, setContext, event: machine.event, context }) : undefined;
+      const exit = config.states[machine.value]?.effect?.({
+        send,
+        setContext,
+        event: machine.event,
+        context: machine.context,
+      });
+      return typeof exit === 'function'
+        ? () => exit({ send, setContext, event: machine.event, context: machine.context })
+        : undefined;
       // We are bypassing the linter here because we deliberately want the effects to run:
       // - When the machine state changes or
       // - When a different event was sent (e.g. self-transition)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ type Transition<Context, Events, State extends string, EventString extends strin
       /**
        * A guard function runs before the transition: If the guard returns false the transition will be denied.
        */
-      guard?: (context: Context, event: Event<Events, EventString>) => boolean;
+      guard?: (params: { context: Context; event: Event<Events, EventString> }) => boolean;
     };
 
 type ContextUpdater<Context> = (context: Context) => Context;
@@ -32,17 +32,19 @@ interface MachineStateConfig<Context, Events, State extends string, EventString 
    * Effects are triggered when the state machine enters a given state. If you return a function from your effect,
    * it will be invoked when leaving that state (similarly to how useEffect works in React).
    */
-  effect?: (
-    send: Dispatch<SendEvent<Events, EventString>>,
-    assign: (updater?: ContextUpdater<Context>) => { send: Dispatch<SendEvent<Events, EventString>> },
-    event?: Event<Events, EventString>
-  ) =>
+  effect?: (params: {
+    send: Dispatch<SendEvent<Events, EventString>>;
+    setContext: (updater?: ContextUpdater<Context>) => { send: Dispatch<SendEvent<Events, EventString>> };
+    event?: Event<Events, EventString>;
+    context: Context;
+  }) =>
     | void
-    | ((
-        send: Dispatch<SendEvent<Events, EventString>>,
-        assign: (updater?: ContextUpdater<Context>) => { send: Dispatch<SendEvent<Events, EventString>> },
-        event?: Event<Events, EventString>
-      ) => void);
+    | ((params: {
+        send: Dispatch<SendEvent<Events, EventString>>;
+        setContext: (updater?: ContextUpdater<Context>) => { send: Dispatch<SendEvent<Events, EventString>> };
+        event?: Event<Events, EventString>;
+        context: Context;
+      }) => void);
 }
 
 interface MachineConfig<Context, Events, State extends string, EventString extends string> {
@@ -168,7 +170,7 @@ function getReducer<Context, Events, State extends string, EventString extends s
       } else {
         target = nextState.target;
         // If there are guards, invoke them and return early if the transition is denied
-        if (nextState.guard && !nextState.guard(state.context, eventObject)) {
+        if (nextState.guard && !nextState.guard({ context: state.context, event: eventObject })) {
           if (config.verbose)
             log(
               `Transition from "${state.value}" to "${target}" denied by guard`,
@@ -220,7 +222,7 @@ function useStateMachineImpl<Context, Events>(context: Context): UseStateMachine
     );
 
     // The updater function sends an internal event to the reducer to trigger the actual update
-    const update = (updater?: ContextUpdater<Context>) => {
+    const setContext = (updater?: ContextUpdater<Context>) => {
       if (updater) {
         dispatch({
           type: DispatchType.Update,
@@ -231,8 +233,8 @@ function useStateMachineImpl<Context, Events>(context: Context): UseStateMachine
     };
 
     useEffect(() => {
-      const exit = config.states[machine.value]?.effect?.(send, update, machine.event);
-      return typeof exit === 'function' ? () => exit(send, update, machine.event) : undefined;
+      const exit = config.states[machine.value]?.effect?.({ send, setContext, event: machine.event, context });
+      return typeof exit === 'function' ? () => exit({ send, setContext, event: machine.event, context }) : undefined;
       // We are bypassing the linter here because we deliberately want the effects to run:
       // - When the machine state changes or
       // - When a different event was sent (e.g. self-transition)

--- a/test-d/useStateMachine.test-d.ts
+++ b/test-d/useStateMachine.test-d.ts
@@ -54,9 +54,9 @@ const machine2 = useStateMachine<{ time: number }>({ time: 0 })({
           target: 'running',
         },
       },
-      effect(send, update) {
+      effect({send, setContext}) {
         expectAssignable<Dispatch<'START' | 'PAUSE' | 'RESET' | { type: 'START' } | { type: 'PAUSE' } | { type: 'RESET' }>>(send);
-        expectAssignable<(value: (context: { time: number }) => { time: number }) => void>(update);
+        expectAssignable<(value: (context: { time: number }) => { time: number }) => void>(setContext);
       },
     },
     running: {
@@ -69,7 +69,7 @@ const machine2 = useStateMachine<{ time: number }>({ time: 0 })({
         RESET: 'idle',
         START: {
           target: 'running',
-          guard(context, event) {
+          guard({context, event}) {
             expectType<{ time: number }>(context)
             expectType<{ type: "START" | "PAUSE" | "RESET"; [key: string]: any; }>(event)
             return true;

--- a/test/useStateMachine.test.tsx
+++ b/test/useStateMachine.test.tsx
@@ -195,6 +195,34 @@ describe('useStateMachine', () => {
       expect(exit.mock.calls[0][0]).toBe('inactive');
     });
 
+    it('should transition from effect', () => {
+      const { result } = renderHook(() =>
+        useStateMachine()({
+          initial: 'inactive',
+          states: {
+            inactive: {
+              on: { TOGGLE: 'active' },
+              effect({ send }) {
+                send('TOGGLE');
+              },
+            },
+            active: {
+              on: { TOGGLE: 'inactive' },
+            },
+          },
+        })
+      );
+
+      expect(result.current[0]).toStrictEqual({
+        context: undefined,
+        event: {
+          type: 'TOGGLE',
+        },
+        value: 'active',
+        nextEvents: ['TOGGLE'],
+      });
+    });
+
     it('should get payload sent with event object', () => {
       const effect = jest.fn();
       const { result } = renderHook(() =>


### PR DESCRIPTION
- Adds access to context from whithin effects
- Renames `update` to `setContext`
- Changes parameter signature for both Effects and Guards to an object.

In E.g.: Instead of this:

```typescript
effect(_, update, _, context) {
    // ...
}
``` 
this:

```typescript
effect({setContext, context}) {
    // ...
}
```



Closes #33 