### PR TITLE
Top-level `on`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,6 +60,12 @@ interface MachineConfig<Context, Events, State extends string, EventString exten
   states: {
     [key in State]: MachineStateConfig<Context, Events, State, EventString>;
   };
+  /**
+   * Defines what the next state is, given the current state and event.
+   */
+  on?: {
+    [key in EventString]?: Transition<Context, Events, State, EventString>;
+  };
 }
 
 interface MachineState<Context, Events, State extends string, EventString extends string> {
@@ -114,7 +120,7 @@ function getState<Context, Events, State extends string, EventString extends str
   value: State,
   event?: Event<Events, EventString>
 ): MachineState<Context, Events, State, EventString> {
-  const on = config.states[value].on;
+  const on = { ...config.states[value].on, ...config.on };
 
   return {
     value,
@@ -149,7 +155,7 @@ function getReducer<Context, Events, State extends string, EventString extends s
       >;
 
       const nextState: Transition<Context, Events, State, EventString> | undefined =
-        currentState.on?.[eventObject.type];
+        currentState.on?.[eventObject.type] ?? config.on?.[eventObject.type];
 
       // If there is no defined next state, return early
       if (!nextState) {

--- a/test-d/useStateMachine.test-d.ts
+++ b/test-d/useStateMachine.test-d.ts
@@ -2,7 +2,7 @@
 import type { Dispatch } from 'react';
 import useStateMachine from '../src';
 import { expectType, expectError, expectAssignable } from 'tsd';
- 
+
 expectError(useStateMachine()({
   initial: '--nonexisting state---',
   states: {
@@ -44,7 +44,33 @@ expectAssignable<{
 }>(machine1[0]);
 expectAssignable<Dispatch<'TOGGLE' | { type: 'TOGGLE' }>>(machine1[1]);
 
-const machine2 = useStateMachine<{ time: number }>({ time: 0 })({
+const machine2 = useStateMachine()({
+  initial: 'inactive',
+  states: {
+    inactive: {
+      on: { TOGGLE: 'active' },
+    },
+    active: {
+      on: { TOGGLE: 'inactive' },
+    },
+  },
+  on: {
+    DEACTIVATE: 'inactive'
+  }
+});
+
+expectAssignable<{
+  value: 'inactive' | 'active';
+  context: undefined;
+  event?: { type: 'TOGGLE' } | { type: 'DEACTIVATE' };
+  nextEvents: ('TOGGLE'|'DEACTIVATE')[];
+}>(machine2[0]);
+
+expectAssignable<Dispatch<'TOGGLE' | { type: 'TOGGLE' }>>(machine2[1]);
+expectAssignable<Dispatch<'DEACTIVATE' | { type: 'DEACTIVATE' }>>(machine2[1]);
+
+
+const machine3 = useStateMachine<{ time: number }>({ time: 0 })({
   initial: 'idle',
   verbose: true,
   states: {
@@ -83,8 +109,8 @@ expectAssignable<{
   value: 'idle' | 'running' | 'paused';
   context: { time: number };
   nextEvents: ('START' | 'PAUSE' | 'RESET')[];
-}>(machine2[0]);
-expectAssignable<Dispatch<'START' | 'PAUSE' | 'RESET' | { type: 'START' } | { type: 'PAUSE' } | { type: 'RESET' }>>(machine2[1]);
+}>(machine3[0]);
+expectAssignable<Dispatch<'START' | 'PAUSE' | 'RESET' | { type: 'START' } | { type: 'PAUSE' } | { type: 'RESET' }>>(machine3[1]);
 
 const machine4 = useStateMachine<undefined, {}>()({
   initial: 'inactive',

--- a/test/useStateMachine.test.tsx
+++ b/test/useStateMachine.test.tsx
@@ -60,6 +60,38 @@ describe('useStateMachine', () => {
       });
     });
 
+    it('should transition using a top-level `on`', () => {
+      const { result } = renderHook(() =>
+        useStateMachine()({
+          initial: 'inactive',
+          states: {
+            inactive: {
+              on: { TOGGLE: 'active' },
+            },
+            active: {
+              on: { TOGGLE: 'inactive' },
+            },
+          },
+          on: {
+            ACTIVATE: 'active',
+          },
+        })
+      );
+
+      act(() => {
+        result.current[1]('ACTIVATE');
+      });
+
+      expect(result.current[0]).toStrictEqual({
+        context: undefined,
+        event: {
+          type: 'ACTIVATE',
+        },
+        value: 'active',
+        nextEvents: ['TOGGLE', 'ACTIVATE'],
+      });
+    });
+
     it('should transition using an object event', () => {
       const { result } = renderHook(() =>
         useStateMachine()({


### PR DESCRIPTION
Closes #41 