### PR TITLE
Filter out transitions with undefined values from `state.nextEvents`.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -122,13 +122,16 @@ function getState<Context, Events, State extends string, EventString extends str
   value: State,
   event?: Event<Events, EventString>
 ): MachineState<Context, Events, State, EventString> {
-  const on = { ...config.states[value].on, ...config.on };
+  const on: Record<string, unknown> = {
+    ...config.states[value].on,
+    ...config.on,
+  };
 
   return {
     value,
     context,
     event,
-    nextEvents: on ? (Object.keys(on) as EventString[]) : [],
+    nextEvents: on ? (Object.keys(on).filter(key => !!on[key]) as EventString[]) : [],
   };
 }
 

--- a/test/useStateMachine.test.tsx
+++ b/test/useStateMachine.test.tsx
@@ -431,6 +431,32 @@ describe('useStateMachine', () => {
       });
     });
 
+    it('should ignore events with nullish values', () => {
+      const { result } = renderHook(() =>
+        useStateMachine()({
+          initial: 'inactive',
+          states: {
+            inactive: {
+              on: {
+                TOGGLE: 'active',
+                ACTIVATE: undefined,
+              },
+            },
+            active: {
+              on: { TOGGLE: 'inactive' },
+            },
+          },
+        })
+      );
+
+      expect(result.current[0]).toStrictEqual({
+        value: 'inactive',
+        context: undefined,
+        event: undefined,
+        nextEvents: ['TOGGLE'],
+      });
+    });
+
     it('should update context on entry', () => {
       const { result } = renderHook(() =>
         useStateMachine<{ toggleCount: number }>({ toggleCount: 0 })({


### PR DESCRIPTION
## What

Don't include keys with undefined values in `nextEvents`.

## Why

In lieu of https://github.com/cassiozen/useStateMachine/issues/46, this allows configuration to be changed based on values which don't change after initial render. Example:

```tsx
// 50% of people won't see the "confirmation" step:
const confirmationEnabled = useFeatureFlag("show-confirmation");

const [state, send] = useStateMachine()({
  states: {
    registration: {
      on: {
        NEXT: showConfirmation ? "confirmation" : undefined
      }
    }
    // other states
  }
})
```

This works with TypeScript, and sending "NEXT" correctly doesn't transition, but `state.nextEvents` shows `["NEXT"]`.
With this PR, `state.nextEvents` is `[]` if `confirmationEnabled` is `false`.