### PR TITLE
feat(dx): instantiate all boundary types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,4 +144,4 @@ const createLogger = (definition: Machine.Definition.Impl) => (groupLabel: strin
 const useStateMachine = useStateMachineImpl as unknown as UseStateMachine;
 export default useStateMachine;
 
-export const t = <T extends unknown>() => ({ [$$t]: undefined as T })
+export const t = <T>() => ({ [$$t]: undefined as unknown as T })

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,9 +127,10 @@ export namespace Machine {
       | { target: TargetString
         , guard?:
             ( parameter:
+              A.Instantiate<
               { context: Machine.Context<D>
               , event: U.Extract<Machine.Event<D>, Event>
-              }
+              }>
             ) => boolean
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -501,6 +501,7 @@ export namespace A {
       : Error
 
   export type Instantiate<T> =
+    T extends InstantiateBlockList ? T :
     T extends any
       ? T extends A.Function
           ? T extends { (...a: infer A1): infer R1, (...a: infer A2): infer R2 }
@@ -514,6 +515,13 @@ export namespace A {
           ? { [K in keyof T]: Instantiate<T[K]> } :
         T
       : never
+
+  type InstantiateBlockList =
+    | { [Symbol.toStringTag]: string }
+    | Error
+    | Date
+    | RegExp
+    | Generator
 
   export type Tag<N extends A.String> =
     { [_ in N]: void }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,8 @@ import { R } from "./extras"
 
 export type UseStateMachine =
   <D extends Machine.Definition<D>>(definition: A.InferNarrowestObject<D>) =>
-    [ state: A.Instantiate<Machine.State<Machine.Definition.FromTypeParamter<D>>>
-    , send: A.Instantiate<Machine.Send<Machine.Definition.FromTypeParamter<D>>>
+    [ state: A.Instantiated<Machine.State<Machine.Definition.FromTypeParamter<D>>>
+    , send: A.Instantiated<Machine.Send<Machine.Definition.FromTypeParamter<D>>>
     ]
 
 export const $$t = Symbol("$$t");
@@ -127,9 +127,9 @@ export namespace Machine {
       | { target: TargetString
         , guard?:
             ( parameter:
-              A.Instantiate<
-              { context: Machine.Context<D>
-              , event: U.Extract<Machine.Event<D>, Event>
+              A.Instantiated<
+              { context: A.Uninstantiated<Machine.Context<D>>
+              , event: A.Uninstantiated<U.Extract<Machine.Event<D>, Event>>
               }>
             ) => boolean
         }
@@ -150,9 +150,9 @@ export namespace Machine {
         
 
     export type Effect<D, P, StateValue = L.Pop<L.Popped<P>>> = 
-      (parameter: A.Instantiate<EffectParameterForStateValue<D, StateValue>>) =>
+      (parameter: A.Instantiated<EffectParameterForStateValue<D, StateValue>>) =>
         | void
-        | ((parameter: A.Instantiate<EffectCleanupParameterForStateValue<D, StateValue>>) => void)
+        | ((parameter: A.Instantiated<EffectCleanupParameterForStateValue<D, StateValue>>) => void)
     
     type EffectImpl =
       (parameter: EffectParameter.Impl) =>
@@ -239,8 +239,8 @@ export namespace Machine {
 
   export type Event<D, EventsSchema = A.Get<D, ["schema", "events"], {}>> = 
     | O.Value<{ [T in U.Exclude<keyof EventsSchema, Definition.ExhaustiveIdentifier>]:
-        A.Get<EventsSchema, [T, $$t]> extends infer E
-          ? E extends any ? O.ShallowMerge<{ type: T } & E> : never
+        A.Get<EventsSchema, [T, $$t]> extends infer P
+          ? P extends any ? O.ShallowMerge<{ type: T } & P> : never
           : never
       }>
     | ( A.Get<EventsSchema, Definition.ExhaustiveIdentifier, false> extends true ? never :
@@ -286,17 +286,17 @@ export namespace Machine {
 
   export interface EffectParameterForStateValue<D, StateValue>
     extends BaseEffectParameter<D>
-    { event: Machine.EntryEventForStateValue<D, StateValue>
+    { event: A.Uninstantiated<Machine.EntryEventForStateValue<D, StateValue>>
     }
 
   export interface EffectCleanupParameterForStateValue<D, StateValue>
     extends BaseEffectParameter<D>
-    { event: Machine.ExitEventForStateValue<D, StateValue>
+    { event: A.Uninstantiated<Machine.ExitEventForStateValue<D, StateValue>>
     }
 
   export interface BaseEffectParameter<D>
     { send: Machine.Send<D>
-    , context: Machine.Context<D>
+    , context: A.Uninstantiated<Machine.Context<D>>
     , setContext: Machine.SetContext<D>
     }
 
@@ -352,8 +352,8 @@ export namespace Machine {
   }
 
   export type Send<D> =
-    { (sendable: U.Exclude<Sendable<D>, A.String>): void
-    , (sendable: U.Extract<Sendable<D>, A.String>): void
+    { (sendable: A.Uninstantiated<U.Exclude<Sendable<D>, A.String>>): void
+    , (sendable: A.Uninstantiated<U.Extract<Sendable<D>, A.String>>): void
     }
 
   type SendImpl = (send: Sendable.Impl) => void
@@ -370,7 +370,9 @@ export namespace Machine {
     export type Impl = SetContextImpl;
   }
 
-  export type ContextUpdater<D> = (context: Context<D>) => Context<D>
+  export type ContextUpdater<D> =
+    (context: A.Uninstantiated<Context<D>>) =>
+      A.Uninstantiated<Context<D>>
 
   type ContextUpdaterImpl = (context: Context.Impl) => Context.Impl
   export namespace ContextUpdater {
@@ -387,8 +389,8 @@ export namespace Machine {
   > =
     Value extends any
       ? { value: Value
-        , context: Context<D>
-        , event: EntryEventForStateValue<D, Value>
+        , context: A.Uninstantiated<Context<D>>
+        , event: A.Uninstantiated<EntryEventForStateValue<D, Value>>
         , nextEventsT: A.Get<ExitEventForStateValue<D, Value>, "type">[]
         , nextEvents: NextEvents
         }
@@ -437,7 +439,7 @@ export namespace U {
 
 export namespace O {
   export type Value<T> = T[keyof T];
-  export type ShallowMerge<T> = { [K in keyof T]: T[K] }
+  export type ShallowMerge<T> = { [K in keyof T]: T[K] } & unknown
 }
 
 export namespace A {
@@ -501,28 +503,32 @@ export namespace A {
           : `${S.Assert<Error>} `
       : Error
 
-  export type Instantiate<T> =
-    T extends InstantiateBlockList ? T :
+  export type Instantiated<T> =
+    T extends Uninstantiated<infer U> ? U : 
+    T extends Builtin ? T :
     T extends any
       ? T extends A.Function
           ? T extends { (...a: infer A1): infer R1, (...a: infer A2): infer R2 }
-              ? { (...a: Instantiate<A1>): Instantiate<R1>
-                , (...a: Instantiate<A2>): Instantiate<R2>
+              ? { (...a: Instantiated<A1>): Instantiated<R1>
+                , (...a: Instantiated<A2>): Instantiated<R2>
                 } :
             T extends (...a: infer A1) => infer R1
-              ? (...a1: Instantiate<A1>) => Instantiate<R1> :
+              ? (...a1: Instantiated<A1>) => Instantiated<R1> :
             never :
         T extends A.Object
-          ? { [K in keyof T]: Instantiate<T[K]> } :
+          ? { [K in keyof T]: Instantiated<T[K]> } :
         T
       : never
 
-  type InstantiateBlockList =
+  type Builtin =
     | { [Symbol.toStringTag]: string }
     | Error
     | Date
     | RegExp
     | Generator
+
+  export type Uninstantiated<T> = T & { [$$uninstantiated]: true }
+  declare const $$uninstantiated: unique symbol;
 
   export type Tag<N extends A.String> =
     { [_ in N]: void }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,7 +13,7 @@ const clearLog = () =>
 const useStateMachine =
   ((d: any) =>
     _useStateMachine({ ...d, console: { log: logger } })
-  ) as typeof _useStateMachine
+  ) as any as typeof _useStateMachine
 
 describe("useStateMachine", () => {
   describe("States & Transitions", () => {

--- a/test/types.twoslash-test.ts
+++ b/test/types.twoslash-test.ts
@@ -2,7 +2,7 @@
 import { A, LS, UseStateMachine, CreateType } from "../src/types";
 
 const useStateMachine = (() => []) as any as UseStateMachine;
-const t = (() => {}) as CreateType
+const t = (() => undefined) as unknown as CreateType
 
 const query = () => 
   ((global as any).twoSlashQueries.shift()) as { completions: string[], text: string }

--- a/test/types.twoslash-test.ts
+++ b/test/types.twoslash-test.ts
@@ -1273,3 +1273,38 @@ describe("workaround for #65", () => {
     }
   >())
 })
+
+describe("A.Instantiated", () => {
+  it("does not instantiate builtin objects", () => {
+    let _x: A.Instantiated<Date> = new Date()
+    _x;
+//  ^?
+    expect(query().text).toContain("Date")
+  })
+
+  it("does not instantiate context", () => {
+    interface Something { foo: string }
+    let [_state] = useStateMachine({
+    //     ^?
+      context: { foo: "" } as Something,
+      initial: "a",
+      states: { a: {} }
+    })
+
+    expect(query().text).toContain("Something")
+  })
+
+  it("does not instantiate event payloads deeply", () => {
+    interface Something { foo: string }
+    let [_, _send] = useStateMachine({
+    //        ^?
+      schema: {
+        events: { A: t<{ bar: Something }>() }
+      },
+      initial: "a",
+      states: { a: { on: { A: "a" } } }
+    })
+
+    expect(query().text).toContain("Something")
+  })
+})


### PR DESCRIPTION
I was writing the documentation and realized the errors and quickinfo are horrible, I mean I knew it previously and I tried this before but apparently it did not work or I was doing it wrong, revisited it and now it works.

Basically typescript skips instantiating type for performance reasons and just shows it's name, but with `A.Instantiate` we force typescript to compute and instantiate it.

It comes with some cost that typescript has to do more work and in worst case it might result in "instantiation is too deep or possibly infinite" but I think that won't happen. Even if it happens we'll basically revert this and publish a patch, as it has got nothing to do with code only error messages and quickinfo.

The boundary positions are namely: state, send, effectParameter, effectCleanupParameter, guardParameter.
<details>
<summary>A few examples of the change</summary><br>

Before:

![image](https://user-images.githubusercontent.com/30295578/128439194-05d8d39a-d031-44ec-9f9d-f9d50a11877b.png)

After: 

![image](https://user-images.githubusercontent.com/30295578/128439244-d047b46b-9def-438d-a375-a3d204dfcdbd.png)

Before:

![image](https://user-images.githubusercontent.com/30295578/128439833-b41ab782-3f5b-4e3c-baaa-03b545bd94bf.png)

After:

![image](https://user-images.githubusercontent.com/30295578/128439895-7d3e5f0a-a596-4c42-aa14-3faea7bfb310.png)


Before: 

![image](https://user-images.githubusercontent.com/30295578/128439454-3ccd68b4-7610-48f6-8711-9f8466a5a143.png)

After: 

![image](https://user-images.githubusercontent.com/30295578/128439484-709c652b-59ad-47b4-ae5c-ae3fc1b8816b.png)

Before: 

![image](https://user-images.githubusercontent.com/30295578/128439547-d4e38003-aa29-49da-95fa-69ebb0ee6709.png)

After:

![image](https://user-images.githubusercontent.com/30295578/128439687-9bf78a33-8905-4f38-b6f3-e4fef0fa6a19.png)

</details>
