### PR TITLE
Allow usage of async when returning void in an effect

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,7 @@ export namespace Machine {
     export type Effect<D, P, StateValue = L.Pop<L.Popped<P>>> = 
       (parameter: EffectParameterForStateValue<D, StateValue>) =>
         | void
+        | Promise<void>
         | ((parameter: EffectCleanupParameterForStateValue<D, StateValue>) => void)
     
     type EffectImpl =


### PR DESCRIPTION
This allows usage of _async_ in combination with void effects. E.g.:

```ts
useStateMachine({
  initial: "downloading",
  states: {
    idle: {
      on: {
        DOWNLOAD: "downloading",
      },
    },
    downloading: {
      on: {
        OK: "idle",
      },
      async effect({ setContext }) {
       await Promise.resolve(42)
       setContext({..}).send(..)
      },
    },
  },
});
````