### PR TITLE
Revert "feat(dx): instantiate all boundary types"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,4 +144,4 @@ const createLogger = (definition: Machine.Definition.Impl) => (groupLabel: strin
 const useStateMachine = useStateMachineImpl as unknown as UseStateMachine;
 export default useStateMachine;
 
-export const t = <T>() => ({ [$$t]: undefined as unknown as T })
+export const t = <T extends unknown>() => ({ [$$t]: undefined as T })

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,13 +3,14 @@ import { R } from "./extras"
 
 export type UseStateMachine =
   <D extends Machine.Definition<D>>(definition: A.InferNarrowestObject<D>) =>
-    [ state: A.Instantiated<Machine.State<Machine.Definition.FromTypeParamter<D>>>
-    , send: A.Instantiated<Machine.Send<Machine.Definition.FromTypeParamter<D>>>
+    [ state: Machine.State<Machine.Definition.FromTypeParamter<D>>
+    , send: Machine.Send<Machine.Definition.FromTypeParamter<D>>
     ]
 
 export const $$t = Symbol("$$t");
 type $$t = typeof $$t;
-export type CreateType = <T>() => { [$$t]: T }
+export type CreateType =
+  <T>() => { [$$t]: T }
 
 export namespace Machine {
   export type Definition<
@@ -127,10 +128,9 @@ export namespace Machine {
       | { target: TargetString
         , guard?:
             ( parameter:
-              A.Instantiated<
-              { context: A.Uninstantiated<Machine.Context<D>>
-              , event: A.Uninstantiated<U.Extract<Machine.Event<D>, Event>>
-              }>
+              { context: Machine.Context<D>
+              , event: U.Extract<Machine.Event<D>, Event>
+              }
             ) => boolean
         }
 
@@ -150,9 +150,9 @@ export namespace Machine {
         
 
     export type Effect<D, P, StateValue = L.Pop<L.Popped<P>>> = 
-      (parameter: A.Instantiated<EffectParameterForStateValue<D, StateValue>>) =>
+      (parameter: EffectParameterForStateValue<D, StateValue>) =>
         | void
-        | ((parameter: A.Instantiated<EffectCleanupParameterForStateValue<D, StateValue>>) => void)
+        | ((parameter: EffectCleanupParameterForStateValue<D, StateValue>) => void)
     
     type EffectImpl =
       (parameter: EffectParameter.Impl) =>
@@ -239,8 +239,8 @@ export namespace Machine {
 
   export type Event<D, EventsSchema = A.Get<D, ["schema", "events"], {}>> = 
     | O.Value<{ [T in U.Exclude<keyof EventsSchema, Definition.ExhaustiveIdentifier>]:
-        A.Get<EventsSchema, [T, $$t]> extends infer P
-          ? P extends any ? O.ShallowMerge<{ type: T } & P> : never
+        A.Get<EventsSchema, [T, $$t]> extends infer E
+          ? E extends any ? O.ShallowClean<{ type: T } & E> : never
           : never
       }>
     | ( A.Get<EventsSchema, Definition.ExhaustiveIdentifier, false> extends true ? never :
@@ -271,10 +271,26 @@ export namespace Machine {
   }
 
   export namespace EffectParameter {
+    export interface EffectParameterForStateValue<D, StateValue>
+      extends Base<D>
+      { event: Machine.EntryEventForStateValue<D, StateValue>
+      }
+
     export namespace Cleanup {
+      export interface ForStateValue<D, StateValue>
+        extends Base<D>
+        { event: Machine.ExitEventForStateValue<D, StateValue>
+        }
+      
       export type Impl = EffectParameter.Impl
     }
 
+    export interface Base<D>
+      { send: Machine.Send<D>
+      , context: Machine.Context<D>
+      , setContext: Machine.SetContext<D>
+      }
+  
     export type Impl = EffectParameterImpl;
   }
   export interface EffectParameterImpl
@@ -286,17 +302,17 @@ export namespace Machine {
 
   export interface EffectParameterForStateValue<D, StateValue>
     extends BaseEffectParameter<D>
-    { event: A.Uninstantiated<Machine.EntryEventForStateValue<D, StateValue>>
+    { event: Machine.EntryEventForStateValue<D, StateValue>
     }
 
   export interface EffectCleanupParameterForStateValue<D, StateValue>
     extends BaseEffectParameter<D>
-    { event: A.Uninstantiated<Machine.ExitEventForStateValue<D, StateValue>>
+    { event: Machine.ExitEventForStateValue<D, StateValue>
     }
 
   export interface BaseEffectParameter<D>
     { send: Machine.Send<D>
-    , context: A.Uninstantiated<Machine.Context<D>>
+    , context: Machine.Context<D>
     , setContext: Machine.SetContext<D>
     }
 
@@ -352,8 +368,8 @@ export namespace Machine {
   }
 
   export type Send<D> =
-    { (sendable: A.Uninstantiated<U.Exclude<Sendable<D>, A.String>>): void
-    , (sendable: A.Uninstantiated<U.Extract<Sendable<D>, A.String>>): void
+    { (sendable: U.Exclude<Sendable<D>, A.String>): void
+    , (sendable: U.Extract<Sendable<D>, A.String>): void
     }
 
   type SendImpl = (send: Sendable.Impl) => void
@@ -370,9 +386,7 @@ export namespace Machine {
     export type Impl = SetContextImpl;
   }
 
-  export type ContextUpdater<D> =
-    (context: A.Uninstantiated<Context<D>>) =>
-      A.Uninstantiated<Context<D>>
+  export type ContextUpdater<D> = (context: Context<D>) => Context<D>
 
   type ContextUpdaterImpl = (context: Context.Impl) => Context.Impl
   export namespace ContextUpdater {
@@ -389,8 +403,8 @@ export namespace Machine {
   > =
     Value extends any
       ? { value: Value
-        , context: A.Uninstantiated<Context<D>>
-        , event: A.Uninstantiated<EntryEventForStateValue<D, Value>>
+        , context: Context<D>
+        , event: EntryEventForStateValue<D, Value>
         , nextEventsT: A.Get<ExitEventForStateValue<D, Value>, "type">[]
         , nextEvents: NextEvents
         }
@@ -432,6 +446,11 @@ export namespace S {
       : false;
 }
 
+export namespace F {
+  export type Call<F> = F extends (...args: any[]) => infer R ? R : never;
+  export type Parameters<F> = F extends (...args: infer A) => any ? A : never;
+}
+
 export namespace U {
   export type Extract<T, U> = T extends U ? T : never;
   export type Exclude<T, U> = T extends U ? never : T;
@@ -439,11 +458,12 @@ export namespace U {
 
 export namespace O {
   export type Value<T> = T[keyof T];
-  export type ShallowMerge<T> = { [K in keyof T]: T[K] } & unknown
+  export type ShallowClean<T> = { [K in keyof T]: T[K] }
 }
 
 export namespace A {
   export type Cast<T, U> = T extends U ? T : U;
+  export type Fallback<T, U> = T extends U ? T : U;
   export type Tuple<T = any> = T[] | [T];
   export type Object = object;
   export type String = string;
@@ -488,6 +508,10 @@ export namespace A {
     P extends [infer K1, ...infer Kr] ?
       K1 extends keyof T ?
         _Get<T[K1], Kr, F> :
+      K1 extends Get.Returned$$ ?
+        _Get<T extends (...a: any[]) => infer R ? R : undefined, Kr, F> :
+      K1 extends Get.Parameters$$ ?
+        _Get<T extends (...a: infer A) => any ? A : undefined, Kr, F> :
       F :
     never
 
@@ -496,39 +520,20 @@ export namespace A {
       ? A.Cast<X, any>
       : never
 
+  export namespace Get {
+    const Returned$$ = Symbol("Returned$$");
+    export type Returned$$ = typeof Returned$$;
+
+    const Parameters$$ = Symbol("Parameters$$");
+    export type Parameters$$ = typeof Parameters$$;
+  }
+
   export type CustomError<Error, Place> =
     Place extends (S.IsLiteral<Place> extends true ? Error : A.String)
       ? Place extends `${S.Assert<Error>} `
           ? Error
           : `${S.Assert<Error>} `
       : Error
-
-  export type Instantiated<T> =
-    T extends Uninstantiated<infer U> ? U : 
-    T extends Builtin ? T :
-    T extends any
-      ? T extends A.Function
-          ? T extends { (...a: infer A1): infer R1, (...a: infer A2): infer R2 }
-              ? { (...a: Instantiated<A1>): Instantiated<R1>
-                , (...a: Instantiated<A2>): Instantiated<R2>
-                } :
-            T extends (...a: infer A1) => infer R1
-              ? (...a1: Instantiated<A1>) => Instantiated<R1> :
-            never :
-        T extends A.Object
-          ? { [K in keyof T]: Instantiated<T[K]> } :
-        T
-      : never
-
-  type Builtin =
-    | { [Symbol.toStringTag]: string }
-    | Error
-    | Date
-    | RegExp
-    | Generator
-
-  export type Uninstantiated<T> = T & { [$$uninstantiated]: true }
-  declare const $$uninstantiated: unique symbol;
 
   export type Tag<N extends A.String> =
     { [_ in N]: void }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,7 +13,7 @@ const clearLog = () =>
 const useStateMachine =
   ((d: any) =>
     _useStateMachine({ ...d, console: { log: logger } })
-  ) as any as typeof _useStateMachine
+  ) as typeof _useStateMachine
 
 describe("useStateMachine", () => {
   describe("States & Transitions", () => {

--- a/test/types.twoslash-test.ts
+++ b/test/types.twoslash-test.ts
@@ -2,7 +2,7 @@
 import { A, LS, UseStateMachine, CreateType } from "../src/types";
 
 const useStateMachine = (() => []) as any as UseStateMachine;
-const t = (() => undefined) as unknown as CreateType
+const t = (() => {}) as CreateType
 
 const query = () => 
   ((global as any).twoSlashQueries.shift()) as { completions: string[], text: string }
@@ -1272,39 +1272,4 @@ describe("workaround for #65", () => {
     , (sendable: "B"): void
     }
   >())
-})
-
-describe("A.Instantiated", () => {
-  it("does not instantiate builtin objects", () => {
-    let _x: A.Instantiated<Date> = new Date()
-    _x;
-//  ^?
-    expect(query().text).toContain("Date")
-  })
-
-  it("does not instantiate context", () => {
-    interface Something { foo: string }
-    let [_state] = useStateMachine({
-    //     ^?
-      context: { foo: "" } as Something,
-      initial: "a",
-      states: { a: {} }
-    })
-
-    expect(query().text).toContain("Something")
-  })
-
-  it("does not instantiate event payloads deeply", () => {
-    interface Something { foo: string }
-    let [_, _send] = useStateMachine({
-    //        ^?
-      schema: {
-        events: { A: t<{ bar: Something }>() }
-      },
-      initial: "a",
-      states: { a: { on: { A: "a" } } }
-    })
-
-    expect(query().text).toContain("Something")
-  })
 })


### PR DESCRIPTION
Reverts cassiozen/useStateMachine#76 - it causes problems with setContext on useEffect:
<img width="861" alt="Screen Shot 2022-01-14 at 6 05 46 PM" src="https://user-images.githubusercontent.com/33676/149600101-c0aa276e-bd3b-4678-9728-d027fe536a2a.png">

