### PR TITLE
Updated README.md with default import

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ npm install @cassiozen/usestatemachine
 ## Sample Usage
 
 ```typescript
+import useStateMachine from "@cassiozen/usestatemachine";
+
 const [state, send] = useStateMachine({
   initial: 'inactive',
   states: {


### PR DESCRIPTION
Let's help newcomers streamline their way towards their first hello world.

This commit makes it clear that the library exports the hook as a default export in contrast to common React hooks.